### PR TITLE
Pixel Order Options

### DIFF
--- a/OpenPixelControl/MessageGenerator.cs
+++ b/OpenPixelControl/MessageGenerator.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+
+namespace OpenPixelControl
+{
+    public static class MessageGenerator
+    {
+        public static List<byte> Generate(List<Pixel> pixels, int channel = 0, PixelOrder pixelOrder = PixelOrder.GRB)
+        {
+            var message = new List<byte>();
+
+            BuildHeader(pixels, message, channel);
+            BuildPixels(pixels, message, pixelOrder);
+
+            return message;
+        }
+
+        static void BuildHeader(List<Pixel> pixels, List<byte> message, int channel)
+        {
+            var lenHighByte = pixels.Count * 3 / 256;
+            var lenLowByte = pixels.Count * 3 % 256;
+
+            message.Add((byte)channel);
+            message.Add(0x00);
+            message.Add((byte)lenHighByte);
+            message.Add((byte)lenLowByte);
+        }
+
+        static void BuildPixels(List<Pixel> pixels, List<byte> message, PixelOrder pixelOrder)
+        {
+            switch (pixelOrder)
+            {
+                case PixelOrder.GRB:
+                    foreach (var pixel in pixels)
+                    {
+                        message.Add(pixel.Green);
+                        message.Add(pixel.Red);
+                        message.Add(pixel.Blue);
+                    }
+
+                    break;
+
+                case PixelOrder.RGB:
+                    foreach (var pixel in pixels)
+                    {
+                        message.Add(pixel.Red);
+                        message.Add(pixel.Green);
+                        message.Add(pixel.Blue);
+                    }
+
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(pixelOrder), pixelOrder, null);
+            }
+        }
+    }
+}

--- a/OpenPixelControl/OpcClient.cs
+++ b/OpenPixelControl/OpcClient.cs
@@ -34,10 +34,8 @@ namespace OpenPixelControl
             // add pixel data
             foreach (var pixel in pixels)
             {
-                // bad string of LEDs or is the data swapped???
-                // shoud be R G B not G R B
-                message.Add(pixel.Green);
                 message.Add(pixel.Red);
+                message.Add(pixel.Green);
                 message.Add(pixel.Blue);
             }
 

--- a/OpenPixelControl/OpcClient.cs
+++ b/OpenPixelControl/OpcClient.cs
@@ -9,35 +9,21 @@ namespace OpenPixelControl
 {
     public class OpcClient
     {
-        public OpcClient(string server = "127.0.0.1", int port = OpcConstants.DefaultPort)
+        public OpcClient(string server = "127.0.0.1", int port = OpcConstants.DefaultPort, PixelOrder pixelOrder = PixelOrder.GRB)
         {
             Server = server;
             Port = port;
+            PixelOrder = pixelOrder;
         }
 
         public string Server { get; set; }
         public int Port { get; set; }
+        public PixelOrder PixelOrder { get; set; }
 
         public void WriteFrame(List<Pixel> pixels, int channel = 0)
         {
-            var lenHighByte = pixels.Count*3/256;
-            var lenLowByte = pixels.Count*3%256;
-
-            var message = new List<byte>();
-
-            // build header
-            message.Add((byte) channel);
-            message.Add(0x00);
-            message.Add((byte) lenHighByte);
-            message.Add((byte) lenLowByte);
-
-            // add pixel data
-            foreach (var pixel in pixels)
-            {
-                message.Add(pixel.Red);
-                message.Add(pixel.Green);
-                message.Add(pixel.Blue);
-            }
+            // generate message
+            var message = MessageGenerator.Generate(pixels, channel, PixelOrder);
 
             // send pixel data
             SendMessage(message.ToArray());

--- a/OpenPixelControl/OpenPixelControl.csproj
+++ b/OpenPixelControl/OpenPixelControl.csproj
@@ -56,10 +56,12 @@
     <Compile Include="Frame.cs" />
     <Compile Include="FrameAnimation.cs" />
     <Compile Include="LetterWall.cs" />
+    <Compile Include="MessageGenerator.cs" />
     <Compile Include="OpcClient.cs" />
     <Compile Include="OpcConstants.cs" />
     <Compile Include="OpcWebSocketClient.cs" />
     <Compile Include="Pixel.cs" />
+    <Compile Include="PixelOrder.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/OpenPixelControl/PixelOrder.cs
+++ b/OpenPixelControl/PixelOrder.cs
@@ -1,0 +1,11 @@
+namespace OpenPixelControl
+{
+	/// <summary>
+	/// most of NeoPixel has GRB pixels
+	/// </summary>
+	public enum PixelOrder
+	{
+		GRB,
+		RGB
+	}
+}


### PR DESCRIPTION
I found NeoPixels have two types of pixel order.
Most of all is GRB, but others are RGB.
http://www.seansworld.com/docs/arduino/adafruitReference.html

This PR let OPC will configure it.